### PR TITLE
Fixed syntax for locating .d.ts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "email": "agelos.pikoulas@gmail.com"
   },
   "main": "./build/code/upath.js",
+  "types": "./upath.d.ts",
   "preferGlobal": false,
   "scripts": {
     "test": "grunt"
@@ -39,9 +40,6 @@
   },
   "engines": {
     "node": ">=0.10 <=5"
-  },
-  "typescript": {
-    "definition": "upath.d.ts"
   },
   "dependencies": {
     "lodash": "3.x",


### PR DESCRIPTION
Also I noticed

```
  "engines": {
    "node": ">=0.10 <=5"
  },
```

in `package.json` but this PR is only about fixing the .d.ts location.