### PR TITLE
Use modular Lodash imports instead of per-method packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,24 +42,20 @@
   "engines": {
     "node": ">=4 <=9"
   },
-  "dependencies": {
-    "lodash.endswith": "^4.2.1",
-    "lodash.startswith": "^4.2.1",
-    "lodash.isfunction": "^3.0.8",
-    "lodash.isstring": "^4.0.1"
-  },
   "devDependencies": {
     "chai": "~4.0.2",
     "coffee-script": "1.12.6",
     "grunt": "0.4.5",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-urequire": "0.7.x",
-    "lodash": "^4.17.4",
     "mocha": "~3.4.2",
     "uberscore": "0.0.19",
     "underscore.string": "~3.3.4",
     "urequire": "0.7.0-beta.33",
     "urequire-ab-specrunner": "^0.2.5",
     "urequire-rc-inject-version": "^0.1.6"
+  },
+  "dependencies": {
+    "lodash": "^4.17.5"
   }
 }

--- a/source/code/upath.coffee
+++ b/source/code/upath.coffee
@@ -1,8 +1,8 @@
 _ =
-  startsWith: require 'lodash.startswith'
-  endsWith: require 'lodash.endswith'
-  isFunction: require 'lodash.isfunction'
-  isString: require 'lodash.isstring'
+  startsWith: require 'lodash/startsWith'
+  endsWith: require 'lodash/endsWith'
+  isFunction: require 'lodash/isFunction'
+  isString: require 'lodash/isString'
 
 path = require 'path'
 


### PR DESCRIPTION
This was simple enough that I went ahead with it.

Fixes the issue raised in #9. It's the best of both worlds: only the needed parts of Lodash are loaded into memory, and they can [share](https://unpkg.com/lodash/startsWith) [code](https://unpkg.com/lodash/endsWith) with each other, unlike the per-method packages (e.g. look at how much code is duplicated between [`lodash.startswith`](https://unpkg.com/lodash.startswith) and [`lodash.endswith`](https://unpkg.com/lodash.endswith)). This results in the smallest memory footprint possible.