### PR TITLE
Allow any version post 4.x to be used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - 7
   - 8
   - 9
+  - 10
 
 before_script:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dist": "./build"
   },
   "engines": {
-    "node": ">=4 <=9"
+    "node": ">=4"
   },
   "devDependencies": {
     "chai": "~4.0.2",


### PR DESCRIPTION
With Node.js 10 released today, and with `@vue/cli` making use of this library, it is not possible to set the Vue application as 10 is not in the range `=>4 <=9`. This PR tweaks it so any version above Node.js 4 is supported.

Probably fixes #14.

**Edit**:

After doing some research, it seems that the root of the issue is in `webpack` (which vue and many other frameworks use, and also has millions of downloads a week) indirectly depends on this package, did some research and:

```
npm ls upath
/home/kyra/Repositories/WebpackTest
└─┬ webpack@4.6.0
  └─┬ watchpack@1.5.0
    └─┬ chokidar@2.0.3
      └── upath@1.0.4
```

So anyone using yarn in Node.js 10 and any of webpack's +8.6k dependents would encounter this issue.