### PR TITLE
test(): added windows path.resolve & fixed path.parse tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  - 6
-  - 7
   - 8
   - 9
   - 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  - 4
-# - 5 npm ERR! typeerror This is an error with npm itself. Please report this error at:: `npm ERR! typeerror Error: Missing required argument #1`
   - 6
   - 7
   - 8

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -19,7 +19,7 @@ module.exports = gruntFunction = (grunt) ->
         path: 'source/spec'
         dstPath: 'build/spec'
         afterBuild: require('urequire-ab-specrunner').options
-          mochaOptions: '--bail'
+          mochaOptions: '--bail --no-colors'
 
       specWatch: derive: 'spec', watch: true
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "types": "./upath.d.ts",
   "preferGlobal": false,
   "scripts": {
-    "test": "grunt",
-    "build": "grunt lib"
+    "test": "npx grunt",
+    "build": "npx grunt lib"
   },
   "directories": {
     "doc": "./doc",

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Notes:
 
  * upath has no runtime dependencies, except built-in `path` (as of 1.0.4)
 
- * travis-ci tested in node versions 6 to 14 (on linux)
+ * travis-ci tested in node versions 8 to 14 (on linux)
 
  * Also tested on Windows / node@12.18.0 (without CI)      
 

--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,9 @@ Notes:
 
  * upath has no runtime dependencies, except built-in `path` (as of 1.0.4)
 
- * travis-ci tested in node versions 4 to 12
-      
+ * travis-ci tested in node versions 6 to 14 (on linux)
+
+ * Also tested on Windows / node@12.18.0 (without CI)      
 
 ## Why ?
 
@@ -65,7 +66,16 @@ Parsing with `path.parse()` should also be consistent across OSes:
           ✓ `'c:\Windows\Directory\somefile.ext'`      ---> `{ root: '', dir: 'c:/Windows/Directory', base: 'somefile.ext', ext: '.ext', name: 'somefile' }`
                                     // `path.parse()` gives `'{ root: '', dir: '', base: 'c:\\Windows\\Directory\\somefile.ext', ext: '.ext', name: 'c:\\Windows\\Directory\\somefile' }'`
           ✓ `'/root/of/unix/somefile.ext'`             ---> `{ root: '/', dir: '/root/of/unix', base: 'somefile.ext', ext: '.ext', name: 'somefile' }`  // equal to `path.parse()`
-    
+
+
+Using `path.resolve()` also is working as one expects across OSes (this test alone was executed on Windows):
+
+  `upath.resolve(...paths)`        --returns-->
+
+          √ `'"C:\Windows\path\only", "../../reports"'`                               --->           `'C:/Windows/reports'`
+                                                                          // `path.resolve()` gives `''C:\\Windows\\reports''`
+          √ `'"C:\Windows\long\path\mixed/with/unix", "../..", "..\../reports"'`      --->      `'C:/Windows/long/reports'`
+                                                                          // `path.resolve()` gives `''C:\\Windows\\long\\reports''`    
 
 ## Added functions
       

--- a/source/spec/upath-spec.coffee
+++ b/source/spec/upath-spec.coffee
@@ -162,13 +162,42 @@ describe "\n# upath v#{VERSION}", ->
               (input, expected)-> [ # alt line output
                 input
                 expected
-                if not _.isEqual (pathResult = path.parse.call null, input), expected
+                if not _.isEqual (pathResult = path.parse input), expected
                   '\n' +  [1..input.length + 2].map(-> ' ').join('') + " // `path.parse()` gives `'#{ formatObjectToOneLine pathResult }'`"
                 else
                   "  // equal to `path.parse()`"
               ]
               (input, expected)-> ->
-                deepEqual upath.parse.call(null, input), expected
+                deepEqual upath.parse(input), expected
+
+        describe.only """\n
+          Using `path.resolve()` also is working as one expects across OSes:
+
+            `upath.resolve(...paths)`        --returns-->\n
+          """, ->
+
+          inputToExpected =
+            '"C:\\Windows\\path\\only", "../../reports"' :
+              "C:/Windows/reports"
+
+            '"C:\\Windows\\long\\path\\mixed/with/unix", "../..", "..\\../reports"' :
+              "C:/Windows/long/reports"
+
+          getInputAsArray = (pathsAsString) ->
+            pathsAsString.split(', ')
+              .map((aPath) -> _.slice(aPath, 1, aPath.length-1).join(''))
+
+          runSpec inputToExpected,
+            (input, expected)-> [ # alt line output
+              input
+              expected
+              if not _.isEqual (pathResult = path.resolve.apply(null, getInputAsArray input)), expected
+                '\n' +  [1..input.length + 2].map(-> ' ').join('') + " // `path.resolve()` gives `'#{ formatObjectToOneLine pathResult }'`"
+              else
+                "  // equal to `path.resolve()`"
+            ]
+            (input, expected)-> ->
+              deepEqual upath.resolve.apply(null, getInputAsArray(input)), expected
 
   describe """\n
   ## Added functions

--- a/source/spec/upath-spec.coffee
+++ b/source/spec/upath-spec.coffee
@@ -65,7 +65,7 @@ describe "\n# upath v#{VERSION}", ->
 
    * upath has no runtime dependencies, except built-in `path` (as of 1.0.4)
 
-   * travis-ci tested in node versions 6 to 14 (linux)
+   * travis-ci tested in node versions 8 to 14 (linux)
 
    * Also tested on Windows / node@12.18.0
   """, ->

--- a/source/spec/upath-spec.coffee
+++ b/source/spec/upath-spec.coffee
@@ -65,7 +65,9 @@ describe "\n# upath v#{VERSION}", ->
 
    * upath has no runtime dependencies, except built-in `path` (as of 1.0.4)
 
-   * travis-ci tested in node versions 4 to 12
+   * travis-ci tested in node versions 6 to 14 (linux)
+
+   * Also tested on Windows / node@12.18.0
   """, ->
 
     describe """\n
@@ -134,30 +136,39 @@ describe "\n# upath v#{VERSION}", ->
             equal upath.join.apply(null, splitPaths input), expected
 
       # parse is not available in node v0.10
-      if not _.startsWith(process.version, 'v0.10') then describe """\n
-        Parsing with `path.parse()` should also be consistent across OSes:
+      if not _.startsWith(process.version, 'v0.10')
+        describe """\n
+          Parsing with `path.parse()` should also be consistent across OSes:
 
-          `upath.parse(path)`        --returns-->\n
-      """, ->
+            `upath.parse(path)`        --returns-->\n
+          """, ->
 
-        inputToExpected =
-          'c:\\Windows\\Directory\\somefile.ext' :
-            { root: '', dir: 'c:/Windows/Directory', base: 'somefile.ext', ext: '.ext', name: 'somefile' }
-          '/root/of/unix/somefile.ext' :
-            { root: '/', dir: '/root/of/unix', base: 'somefile.ext', ext: '.ext', name: 'somefile' }
+            inputToExpected =
+              'c:\\Windows\\Directory\\somefile.ext' :
+                root: if path.sep is '\\' then 'c:/' else '' # parsing windows dirs not working on linux
+                dir: 'c:/Windows/Directory'
+                base: 'somefile.ext'
+                ext: '.ext'
+                name: 'somefile'
 
+              '/root/of/unix/somefile.ext' :
+                root: '/'
+                dir: '/root/of/unix'
+                base: 'somefile.ext'
+                ext: '.ext'
+                name: 'somefile'
 
-        runSpec inputToExpected,
-          (input, expected)-> [ # alt line output
-            input
-            expected
-            if not _.isEqual (pathResult = path.parse.call null, input), expected
-              '\n' +  [1..input.length + 2].map(-> ' ').join('') + " // `path.parse()` gives `'#{ formatObjectToOneLine pathResult }'`"
-            else
-              "  // equal to `path.parse()`"
-          ]
-          (input, expected)-> ->
-            deepEqual upath.parse.call(null, input), expected
+            runSpec inputToExpected,
+              (input, expected)-> [ # alt line output
+                input
+                expected
+                if not _.isEqual (pathResult = path.parse.call null, input), expected
+                  '\n' +  [1..input.length + 2].map(-> ' ').join('') + " // `path.parse()` gives `'#{ formatObjectToOneLine pathResult }'`"
+                else
+                  "  // equal to `path.parse()`"
+              ]
+              (input, expected)-> ->
+                deepEqual upath.parse.call(null, input), expected
 
   describe """\n
   ## Added functions

--- a/source/spec/upath-spec.coffee
+++ b/source/spec/upath-spec.coffee
@@ -170,34 +170,35 @@ describe "\n# upath v#{VERSION}", ->
               (input, expected)-> ->
                 deepEqual upath.parse(input), expected
 
-        describe.only """\n
-          Using `path.resolve()` also is working as one expects across OSes:
+        if path.sep is '\\'
+          describe """\n
+            Using `path.resolve()` also is working as one expects across OSes (this test alone was executed on Windows):
 
-            `upath.resolve(...paths)`        --returns-->\n
-          """, ->
+              `upath.resolve(...paths)`        --returns-->\n
+            """, ->
 
-          inputToExpected =
-            '"C:\\Windows\\path\\only", "../../reports"' :
-              "C:/Windows/reports"
+            inputToExpected =
+              '"C:\\Windows\\path\\only", "../../reports"' :
+                "C:/Windows/reports"
 
-            '"C:\\Windows\\long\\path\\mixed/with/unix", "../..", "..\\../reports"' :
-              "C:/Windows/long/reports"
+              '"C:\\Windows\\long\\path\\mixed/with/unix", "../..", "..\\../reports"' :
+                "C:/Windows/long/reports"
 
-          getInputAsArray = (pathsAsString) ->
-            pathsAsString.split(', ')
-              .map((aPath) -> _.slice(aPath, 1, aPath.length-1).join(''))
+            getInputAsArray = (pathsAsString) ->
+              pathsAsString.split(', ')
+                .map((aPath) -> _.slice(aPath, 1, aPath.length-1).join(''))
 
-          runSpec inputToExpected,
-            (input, expected)-> [ # alt line output
-              input
-              expected
-              if not _.isEqual (pathResult = path.resolve.apply(null, getInputAsArray input)), expected
-                '\n' +  [1..input.length + 2].map(-> ' ').join('') + " // `path.resolve()` gives `'#{ formatObjectToOneLine pathResult }'`"
-              else
-                "  // equal to `path.resolve()`"
-            ]
-            (input, expected)-> ->
-              deepEqual upath.resolve.apply(null, getInputAsArray(input)), expected
+            runSpec inputToExpected,
+              (input, expected)-> [ # alt line output
+                input
+                expected
+                if not _.isEqual (pathResult = path.resolve.apply(null, getInputAsArray input)), expected
+                  '\n' +  [1..input.length + 2].map(-> ' ').join('') + " // `path.resolve()` gives `'#{ formatObjectToOneLine pathResult }'`"
+                else
+                  "  // equal to `path.resolve()`"
+              ]
+              (input, expected)-> ->
+                deepEqual upath.resolve.apply(null, getInputAsArray(input)), expected
 
   describe """\n
   ## Added functions
@@ -428,7 +429,7 @@ describe "\n# upath v#{VERSION}", ->
       runSpec inputToExpected, (input, expected)-> ->
         equal upath.removeExt(input, '.js'), expected
         equal upath.removeExt(input, 'js'), expected
-    
+
     describe """\n
     It does not care about the length of exts.
 
@@ -438,7 +439,7 @@ describe "\n# upath v#{VERSION}", ->
         'removedExt.longExt': 'removedExt'
         'removedExt.txt.longExt': 'removedExt.txt'
         'notRemoved.txt': 'notRemoved.txt'
-      
+
       runSpec inputToExpected, (input, expected)-> ->
         equal upath.removeExt(input, '.longExt'), expected
         equal upath.removeExt(input, 'longExt'), expected


### PR DESCRIPTION
test(): fix upath.parse() test failing on Windows
test(): add test for path.resolve on windows #35
test(): fix path.resolve() test, only for windows & manualy add it to readme.md. Also mocha started spitting colors, breaking the readme.md generation from tests (and --no-colors doesnt work)