### PR TITLE
improve toUnix

### DIFF
--- a/source/code/upath.coffee
+++ b/source/code/upath.coffee
@@ -11,10 +11,17 @@ upath = exports
 upath.VERSION = if VERSION? then VERSION else 'NO-VERSION' # injected by urequire-inject-version
 
 toUnix = (p) ->
-  p = p.replace /\\/g, '/'
-  double = /\/\//
-  while p.match double
-    p = p.replace double, '/' # node on windows doesn't replace doubles
+  # handle the edge-case of Window's long file names
+  # See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names
+  p = p.replace /^\\\\\?\\/, ""
+  
+  # convert the separator from \ to /
+  p = p.replace(/\\/g, '/')
+  
+  # node on windows doesn't replace back-to-back separators
+  # this also handles/fixes poorly made joins, e.g. path1+path2
+  p = p.replace(/\/+/g, '/')
+  
   p
 
 for propName, propValue of path


### PR DESCRIPTION
- simplifies the logic for replacing `//` with `/`
- partially handles the edgecase of large file names, could probably also add a warning since max path lengths in linux is complicated see: http://insanecoding.blogspot.com/2007/11/pathmax-simply-isnt.html

As a side note: its good to see someone else using coffeescript!