### PR TITLE
Support UNC path beginning with double slashes

### DIFF
--- a/source/code/upath.coffee
+++ b/source/code/upath.coffee
@@ -12,9 +12,7 @@ upath.VERSION = if VERSION? then VERSION else 'NO-VERSION' # injected by urequir
 
 toUnix = (p) ->
   p = p.replace /\\/g, '/'
-  double = /\/\//
-  while p.match double
-    p = p.replace double, '/' # node on windows doesn't replace doubles
+  p = p.replace /(?<!^)\/+/g, '/' # replace doubles except beginning for UNC path
   p
 
 for propName, propValue of path

--- a/source/code/upath.coffee
+++ b/source/code/upath.coffee
@@ -42,18 +42,15 @@ extraFunctions =
 
   normalizeSafe: (p) ->
     p = toUnix(p)
-    if p.startsWith './'
-      if p.startsWith('./..') or (p is './')
-        upath.normalize(p)
+    result = upath.normalize(p)
+    if p.startsWith('./') && !result.startsWith('./') && !result.startsWith('..')
+      result = './' + result
+    else if p.startsWith('//') && !result.startsWith('//')
+      if p.startsWith('//./')
+        result = '//.' + result
       else
-        './' + upath.normalize(p)
-    else if p.startsWith '//'
-      if p.startsWith '//./'
-        upath.normalize(p).replace /^\/+(\.\/+)?(?!$)/, '//./'
-      else
-        upath.normalize(p).replace /^\/+(?!$)/, '//'
-    else
-      upath.normalize(p)
+        result = '/' + result
+    result
 
   normalizeTrim: (p) ->
     p = upath.normalizeSafe p
@@ -65,8 +62,15 @@ extraFunctions =
 
   joinSafe: (p...) ->
     result = upath.join.apply null, p
-    if p[0].startsWith('./') && !result.startsWith('./')
-      result = './' + result
+    if p.length > 0
+      p0 = toUnix(p[0])
+      if p0.startsWith('./') && !result.startsWith('./') && !result.startsWith('..')
+        result = './' + result
+      else if p0.startsWith('//') && !result.startsWith('//')
+        if p0.startsWith('//./')
+          result = '//.' + result
+        else
+          result = '/' + result
     result
 
   addExt: (file, ext) ->

--- a/source/code/upath.coffee
+++ b/source/code/upath.coffee
@@ -47,6 +47,11 @@ extraFunctions =
         upath.normalize(p)
       else
         './' + upath.normalize(p)
+    else if p.startsWith '//'
+      if p.startsWith '//./'
+        upath.normalize(p).replace /^\/+(\.\/+)?(?!$)/, '//./'
+      else
+        upath.normalize(p).replace /^\/+(?!$)/, '//'
     else
       upath.normalize(p)
 

--- a/source/spec/upath-spec.coffee
+++ b/source/spec/upath-spec.coffee
@@ -113,31 +113,6 @@ describe "\n# upath v#{VERSION}", ->
             equal upath.normalize(input), expected
 
       describe """\n
-      Special Windows paths beginning with double (back)slashes:
-
-          `upath.normalizeSafe(path)`        --returns-->\n
-      """, ->
-        inputToExpected =
-          '\\\\server\\share\\file':        '//server/share/file'
-          '\\\\?\\UNC\\server\\share\\file': '//?/UNC/server/share/file'
-          '\\\\LOCALHOST\\c$\\temp\\file':  '//LOCALHOST/c$/temp/file'
-          '\\\\?\\c:\\temp\\file':          '//?/c:/temp/file'
-          '\\\\.\\c:\\temp\\file':          '//./c:/temp/file'
-          '////\\.\\c:/temp\\//file':       '//./c:/temp/file'
-
-        runSpec inputToExpected,
-          (input, expected)-> [ # alt line output
-              input.replace(/\\/g, '\\\\')
-              expected
-              if (pathResult = path.normalize input) isnt expected
-                "  // `path.normalize()` gives `'#{pathResult}'`"
-              else
-                "  // equal to `path.normalize()`"
-            ]
-          (input, expected)-> ->
-            equal upath.normalizeSafe(input), expected
-
-      describe """\n
       Joining paths can also be a problem:
 
           `upath.join(paths...)`        --returns-->\n
@@ -247,7 +222,7 @@ describe "\n# upath v#{VERSION}", ->
     describe """\n
       #### `upath.normalizeSafe(path)`
 
-      Exactly like `path.normalize(path)`, but it keeps the first meaningful `./`.
+      Exactly like `path.normalize(path)`, but it keeps the first meaningful `./` or `//`.
 
       Note that the unix `/` is returned everywhere, so windows `\\` is always converted to unix `/`.
 
@@ -281,6 +256,15 @@ describe "\n# upath v#{VERSION}", ->
           '..//windows\\unix\/mixed': '../windows/unix/mixed'
           'windows\\unix\/mixed/': 'windows/unix/mixed/'
           '..//windows\\..\\unix\/mixed': '../unix/mixed'
+          # UNC paths
+          '\\\\server\\share\\file':          '//server/share/file'
+          '//server/share/file':              '//server/share/file'
+          '\\\\?\\UNC\\server\\share\\file':  '//?/UNC/server/share/file'
+          '\\\\LOCALHOST\\c$\\temp\\file':    '//LOCALHOST/c$/temp/file'
+          '\\\\?\\c:\\temp\\file':            '//?/c:/temp/file'
+          '\\\\.\\c:\\temp\\file':            '//./c:/temp/file'
+          '//./c:/temp/file':                 '//./c:/temp/file'
+          '////\\.\\c:/temp\\//file':         '//./c:/temp/file'
 
         runSpec inputToExpected,
           (input, expected)-> [ # alt line output
@@ -325,7 +309,7 @@ describe "\n# upath v#{VERSION}", ->
     describe """\n
       #### `upath.joinSafe([path1][, path2][, ...])`
 
-      Exactly like `path.join()`, but it keeps the first meaningful `./`.
+      Exactly like `path.join()`, but it keeps the first meaningful `./` or `//`.
 
       Note that the unix `/` is returned everywhere, so windows `\\` is always converted to unix `/`.
 
@@ -338,6 +322,11 @@ describe "\n# upath v#{VERSION}", ->
           './some/local/unix/, ../path' :    './some/local/path'
           './some\\current\\mixed, ..\\path' :    './some/current/path'
           '../some/relative/destination, ..\\path' :    '../some/relative/path'
+          # UNC paths
+          '\\\\server\\share\\file, ..\\path' : '//server/share/path'
+          '\\\\.\\c:\\temp\\file, ..\\path' :   '//./c:/temp/path'
+          '//server/share/file, ../path' :      '//server/share/path'
+          '//./c:/temp/file, ../path' :         '//./c:/temp/path'
 
         runSpec inputToExpected,
           (input, expected)-> [ # alt line output

--- a/source/spec/upath-spec.coffee
+++ b/source/spec/upath-spec.coffee
@@ -100,6 +100,24 @@ describe "\n# upath v#{VERSION}", ->
 
           '\\windows\\..\\unix\/mixed/':    '/unix/mixed/'
 
+        runSpec inputToExpected,
+          (input, expected)-> [ # alt line output
+              input.replace(/\\/g, '\\\\')
+              expected
+              if (pathResult = path.normalize input) isnt expected
+                "  // `path.normalize()` gives `'#{pathResult}'`"
+              else
+                "  // equal to `path.normalize()`"
+            ]
+          (input, expected)-> ->
+            equal upath.normalize(input), expected
+
+      describe """\n
+      Special Windows paths beginning with double (back)slashes:
+
+          `upath.normalizeSafe(path)`        --returns-->\n
+      """, ->
+        inputToExpected =
           '\\\\server\\share\\file':        '//server/share/file'
           '\\\\?\\UNC\\server\\share\\file': '//?/UNC/server/share/file'
           '\\\\LOCALHOST\\c$\\temp\\file':  '//LOCALHOST/c$/temp/file'
@@ -117,7 +135,7 @@ describe "\n# upath v#{VERSION}", ->
                 "  // equal to `path.normalize()`"
             ]
           (input, expected)-> ->
-            equal upath.normalize(input), expected
+            equal upath.normalizeSafe(input), expected
 
       describe """\n
       Joining paths can also be a problem:

--- a/source/spec/upath-spec.coffee
+++ b/source/spec/upath-spec.coffee
@@ -95,10 +95,17 @@ describe "\n# upath v#{VERSION}", ->
           'c:\\windows\\nodejs\\path':      'c:/windows/nodejs/path'
           'c:\\windows\\..\\nodejs\\path':  'c:/nodejs/path'
 
-          '//windows\\unix\/mixed':         '/windows/unix/mixed'
+          '/windows\\unix\/mixed':          '/windows/unix/mixed'
           '\\windows//unix\/mixed':         '/windows/unix/mixed'
 
-          '////\\windows\\..\\unix\/mixed/':    '/unix/mixed/'
+          '\\windows\\..\\unix\/mixed/':    '/unix/mixed/'
+
+          '\\\\server\\share\\file':        '//server/share/file'
+          '\\\\?\\UNC\\server\\share\\file': '//?/UNC/server/share/file'
+          '\\\\LOCALHOST\\c$\\temp\\file':  '//LOCALHOST/c$/temp/file'
+          '\\\\?\\c:\\temp\\file':          '//?/c:/temp/file'
+          '\\\\.\\c:\\temp\\file':          '//./c:/temp/file'
+          '////\\.\\c:/temp\\//file':       '//./c:/temp/file'
 
         runSpec inputToExpected,
           (input, expected)-> [ # alt line output


### PR DESCRIPTION
Replacing double slashes '//' to '/' in `toUnix()` causes problem when the path is a UNC path, beginning with double (back)slashes.

Examples of such pathes:

```
          '\\\\server\\share\\file':        '//server/share/file'
          '\\\\?\\UNC\\server\\share\\file': '//?/UNC/server/share/file'
          '\\\\LOCALHOST\\c$\\temp\\file':  '//LOCALHOST/c$/temp/file'
          '\\\\?\\c:\\temp\\file':          '//?/c:/temp/file'
          '\\\\.\\c:\\temp\\file':          '//./c:/temp/file'
          '////\\.\\c:/temp\\//file':       '//./c:/temp/file'
```

See the following Microsoft documents about Windows path names:

https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file

-----

Now (with the modified version of `toUnix()`), `upath.normalize('\\\\server\\share\\file')` returns '//server/share/file' on Windows but returns '/server/share/file' on Unix. I think this behavior is good in most case, but may be problematic when processing Windows UNC paths on Unix. So I modified the safe version `normalizeSafe()` to preserve leading double slashes. (Update: same for `joinSafe()`)

-----

I noticed a related pull request https://github.com/anodynos/upath/pull/37 . Maybe it is good to omit unnecessary `//?/` prefix. However, we need to keep the leading double slashes of the UNC paths.