### PR TITLE
fix(): do not use RegExp lookbehind assertion, not supported in WebKit

### DIFF
--- a/source/code/upath.coffee
+++ b/source/code/upath.coffee
@@ -12,7 +12,7 @@ upath.VERSION = if VERSION? then VERSION else 'NO-VERSION' # injected by urequir
 
 toUnix = (p) ->
   p = p.replace /\\/g, '/'
-  p = p.replace /(?<!^)\/+/g, '/' # replace doubles except beginning for UNC path
+  p = p.replace /(?!^)\/+/g, '/' # replace doubles except beginning for UNC path
   p
 
 for propName, propValue of path


### PR DESCRIPTION
This is a follow-up fix to https://github.com/anodynos/upath/pull/38.

That was my mistake. The regexp lookbehind assertion `(?<!^)` is not supported in some JavaScript engines, esp. WebKit's, and causes error, so it should not be used yet.

See:
- "lookbehind assertions" in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility
- WebKit issue: [Bug 174931 - Implement RegExp lookbehind assertions](https://bugs.webkit.org/show_bug.cgi?id=174931)
