### PR TITLE
fix: keep the //./ root in normalizeTrim so it stays idempotent

### DIFF
--- a/src/__tests__/safe.test.ts
+++ b/src/__tests__/safe.test.ts
@@ -71,6 +71,10 @@ describe('upath safe functions', () => {
       // Root edge cases
       ['/', '/'],
       ['//', '/'],
+      // The `//./` DOS-device/UNC root is structural, like `/`, so its
+      // trailing slash must be kept (otherwise normalizeTrim is not idempotent).
+      ['//.//', '//./'],
+      ['//./', '//./'],
     ]
 
     test.each(cases)('normalizeTrim(%j) → %j', (input, expected) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,11 +81,11 @@ function normalizeSafe(p: string): string {
 
 /**
  * Like `normalizeSafe` but also trims a trailing slash (unless the path is
- * root `/`).
+ * root `/` or the `//./` DOS-device/UNC root).
  */
 function normalizeTrim(p: string): string {
   p = normalizeSafe(p)
-  if (p.endsWith('/') && p.length > 1) {
+  if (p.endsWith('/') && p.length > 1 && p !== '//./') {
     return p.slice(0, -1)
   }
   return p


### PR DESCRIPTION
## Problem

`normalizeTrim` is not idempotent for the `//./` DOS-device/UNC root. `normalizeSafe` preserves that root, but `normalizeTrim` trims its trailing slash and produces an invalid path that reduces further on a second pass:

```js
const upath = require('upath');

upath.normalizeSafe('//.//')                  // '//./'   (root preserved)
upath.normalizeTrim('//.//')                  // '//.'    <- not a valid normalized path
upath.normalizeTrim(upath.normalizeTrim('//.//'))  // '/'  <- output changes on re-feed
```

`normalizeSafe` is idempotent (its UNC handling is covered by the existing `safe.test.ts` UNC block); `normalizeTrim` should be too.

## Cause

`src/index.ts`:

```ts
function normalizeTrim(p: string): string {
  p = normalizeSafe(p)
  if (p.endsWith('/') && p.length > 1) {   // trims the trailing slash unconditionally
    return p.slice(0, -1)
  }
  return p
}
```

`normalizeSafe('//.//')` returns `'//./'`, then the trailing slash is stripped to `'//.'`. Feeding `'//.'` back in, `normalizeSafe` treats it as the generic `//` case and yields `'//'`, which trims to `'/'`. The `//./` root is the UNC analogue of `/` — like `/`, its trailing slash is structural and must not be trimmed.

## Fix

Keep the trailing slash for `//./`, mirroring the existing `length > 1` guard that already keeps `/`.

## Tests

Added `['//.//', '//./']` and `['//./', '//./']` to the existing `normalizeTrim` cases. They fail on `master` (`'//.'`) and pass with the fix; the existing cases are unchanged. Full suite green (423 tests).